### PR TITLE
Fixed $HOME env var issue

### DIFF
--- a/nzbdrone
+++ b/nzbdrone
@@ -6,19 +6,19 @@
 # Add the following lines to /etc/rc.conf.local or /etc/rc.conf
 # to enable this service:
 #
-# nzbdrone_enable (bool):       Set to NO by default.
-#                       Set it to YES to enable it.
-# nzbdrone_data_dir:    Directory where nzbdrone configuration
-#                       data is stored.
-#                       Default: /home/${nzbdrone_user}/.config/NzbDrone
-# nzbdrone_user:        The user account nzbdrone daemon runs as what
-#                       you want it to be. It uses '%%USER%%' user by
-#                       default. Do not sets it as empty or it will run
-#                       as root.
-# nzbdrone_group:       The group account nzbdrone daemon runs as what
-#                       you want it to be. It uses '%%GROUP%%' group by
-#                       default. Do not sets it as empty or it will run
-#                       as wheel.
+# nzbdrone_enable (bool):	Set to NO by default.
+#			Set it to YES to enable it.
+# nzbdrone_data_dir:	Directory where nzbdrone configuration
+#			data is stored.
+#			Default: /home/${nzbdrone_user}/.config/NzbDrone
+# nzbdrone_user:	The user account nzbdrone daemon runs as what
+#			you want it to be. It uses '%%USER%%' user by
+#			default. Do not sets it as empty or it will run
+#			as root.
+# nzbdrone_group:	The group account nzbdrone daemon runs as what
+#			you want it to be. It uses '%%GROUP%%' group by
+#			default. Do not sets it as empty or it will run
+#			as wheel.
 
 . /etc/rc.subr
 name="nzbdrone"
@@ -41,7 +41,7 @@ command="/usr/local/bin/mono"
 command_args="$nzbdrone_dir/NzbDrone.exe >$nzbdrone_log 2>&1 &"
 nzbdrone_poststart()
 {
-        echo `ps ax | grep "NzbDrone.exe" | grep -v grep | awk '{print $1}'` > $pidfile
+	echo `ps ax | grep "NzbDrone.exe" | grep -v grep | awk '{print $1}'` > $pidfile
 }
 nzbdrone_poststop()
 {

--- a/nzbdrone
+++ b/nzbdrone
@@ -6,19 +6,19 @@
 # Add the following lines to /etc/rc.conf.local or /etc/rc.conf
 # to enable this service:
 #
-# nzbdrone_enable (bool):	Set to NO by default.
-#			Set it to YES to enable it.
-# nzbdrone_data_dir:	Directory where nzbdrone configuration
-#			data is stored.
-#			Default: /home/${nzbdrone_user}/.config/NzbDrone
-# nzbdrone_user:	The user account nzbdrone daemon runs as what
-#			you want it to be. It uses '%%USER%%' user by
-#			default. Do not sets it as empty or it will run
-#			as root.
-# nzbdrone_group:	The group account nzbdrone daemon runs as what
-#			you want it to be. It uses '%%GROUP%%' group by
-#			default. Do not sets it as empty or it will run
-#			as wheel.
+# nzbdrone_enable (bool):       Set to NO by default.
+#                       Set it to YES to enable it.
+# nzbdrone_data_dir:    Directory where nzbdrone configuration
+#                       data is stored.
+#                       Default: /home/${nzbdrone_user}/.config/NzbDrone
+# nzbdrone_user:        The user account nzbdrone daemon runs as what
+#                       you want it to be. It uses '%%USER%%' user by
+#                       default. Do not sets it as empty or it will run
+#                       as root.
+# nzbdrone_group:       The group account nzbdrone daemon runs as what
+#                       you want it to be. It uses '%%GROUP%%' group by
+#                       default. Do not sets it as empty or it will run
+#                       as wheel.
 
 . /etc/rc.subr
 name="nzbdrone"
@@ -27,6 +27,7 @@ load_rc_config $name
 start_postcmd="${name}_poststart"
 pidfile="/var/run/${name}.pid"
 stop_postcmd="${name}_poststop"
+start_precmd="${name}_prestart"
 
 
 : ${nzbdrone_enable:="NO"}
@@ -40,10 +41,14 @@ command="/usr/local/bin/mono"
 command_args="$nzbdrone_dir/NzbDrone.exe >$nzbdrone_log 2>&1 &"
 nzbdrone_poststart()
 {
-	echo `ps ax | grep "NzbDrone.exe" | grep -v grep | awk '{print $1}'` > $pidfile
+        echo `ps ax | grep "NzbDrone.exe" | grep -v grep | awk '{print $1}'` > $pidfile
 }
 nzbdrone_poststop()
 {
         rm $pidfile
+}
+nzbdrone_prestart()
+{
+        export HOME=`su $nzbdrone_user -c 'echo $HOME'`
 }
 run_rc_command "$1"


### PR DESCRIPTION
I had the problem that for some reason the $HOME var was set to /, which caused nzbdrone to try to read files from /.config and not running because of that. I inserted a force set of the $HOME var which fixed that issue for me. 